### PR TITLE
Fix README logo image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 English | [日本語](README_JP.md)
 
 <p align="center">
-  <img src="assets/images/logo.png" alt="PhotoVoca Logo" width="200"/>
+  <img src="assets/images/photovoca.png" alt="PhotoVoca Logo" width="200"/>
 </p>
 
 A Flutter application that transforms everyday objects into English vocabulary learning opportunities through camera-based object recognition.

--- a/README_JP.md
+++ b/README_JP.md
@@ -3,7 +3,7 @@
 [English](README.md) | 日本語
 
 <p align="center">
-  <img src="assets/images/logo.png" alt="PhotoVoca Logo" width="200"/>
+  <img src="assets/images/photovoca.png" alt="PhotoVoca Logo" width="200"/>
 </p>
 
 カメラで撮影した物体を自動認識し、英語の語彙学習に変換するFlutterアプリケーションです。


### PR DESCRIPTION
## Summary
- Fixed logo image path in README.md and README_JP.md from `logo.png` to `photovoca.png` to match the actual file name

## Test plan
- [x] Verified the actual logo file exists at `assets/images/photovoca.png`
- [x] Confirmed README files now reference the correct path